### PR TITLE
🔧 Configure PyUp to run monthly on development

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,7 @@
 # https://pyup.io/docs/configuration/
-
-update: all
+branch: development
+branch_prefix: update/
 pin: True
-schedule: "every week on thursday"
+pr_prefix: "❗️ "
+schedule: "every month"
+update: all


### PR DESCRIPTION
While roman-numerals is still under development, the weekly updates
affect the development setup, not the actual security of the package
itself. As such, to save myself time, I'm switching the PyUp bot to open
PRs on a monthly basis.

This also adds an emoji prefix to the PRs. For reasons.